### PR TITLE
fixed initial progress error during resume, after multiple pause resumes

### DIFF
--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -40,6 +40,8 @@ class DownloadManager {
 
   Future<void> download(String url, String savePath, cancelToken,
       {forceDownload = false}) async {
+    late String partialFilePath;
+    late File partialFile;
     try {
       var task = getDownload(url);
 
@@ -52,8 +54,8 @@ class DownloadManager {
         print(url);
       }
       var file = File(savePath.toString());
-      var partialFilePath = savePath + partialExtension;
-      var partialFile = File(partialFilePath);
+      partialFilePath = savePath + partialExtension;
+      partialFile = File(partialFilePath);
 
       var fileExist = await file.exists();
       var partialFileExist = await partialFile.exists();
@@ -110,6 +112,13 @@ class DownloadManager {
           _startExecution();
         }
         rethrow;
+      } else if (task.status.value == DownloadStatus.paused) {
+        final ioSink = partialFile.openWrite(mode: FileMode.writeOnlyAppend);
+        final f = File(partialFilePath + tempExtension);
+        if (await f.exists()) {
+          await ioSink.addStream(f.openRead());
+        }
+        await ioSink.close();
       }
     }
 


### PR DESCRIPTION
[progress error · Issue #12 · nabil6391/flutter_download_manager](https://github.com/nabil6391/flutter_download_manager/issues/12)

Problem:
The task was paused first, then resumed, repeated several times, and the initial progress was found to be wrong when resumed。Restoration progress will start from partialFile.length()

Reason:
The reason is that the current progress is not written to the partialFile during the pause。

Is the condition task.status.value == DownloadStatus.paused too broad? , or should add e instanceof CancelToken? If dio.download throws other exceptions, it seems that keeping the downloaded content is also feasible. Here we need to discuss the scope of conditions

