### PR TITLE
Add dio as an option to DownloadManager

### DIFF
--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -23,10 +23,16 @@ class DownloadManager {
 
   DownloadManager._internal();
 
-  factory DownloadManager({int? maxConcurrentTasks}) {
+  factory DownloadManager({
+    int? maxConcurrentTasks,
+    Dio? dio,
+  }) {
     if (maxConcurrentTasks != null) {
       _dm.maxConcurrentTasks = maxConcurrentTasks;
     }
+
+    _dm.dio = dio ?? Dio();
+
     return _dm;
   }
 


### PR DESCRIPTION
This pull request adds an optional "dio" parameter to the DownloadManager factory constructor.

In my specific use case, I need to set a custom User-Agent header for requests made by the DownloadManager. By passing in my own instance of Dio with a customized User-Agent header, I can ensure that the requests made by the DownloadManager include the necessary User-Agent header.

Let me know if you have any feedback. 